### PR TITLE
remove 0.0.0.0 clients6.google.com

### DIFF
--- a/Extension/GoodbyeAds-YouTube-AdBlock.txt
+++ b/Extension/GoodbyeAds-YouTube-AdBlock.txt
@@ -52,7 +52,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 analytic-google.com
 0.0.0.0 clients.l.google.com
 0.0.0.0 clients1.google.com
-0.0.0.0 clients6.google.com
 0.0.0.0 doubleclick.net
 0.0.0.0 dts.innovid.com
 0.0.0.0 files.adform.net

--- a/Formats/GoodbyeAds-YouTube-AdBlock-Filter.txt
+++ b/Formats/GoodbyeAds-YouTube-AdBlock-Filter.txt
@@ -33,7 +33,6 @@
 ||analytic-google.com^
 ||clients.l.google.com^
 ||clients1.google.com^
-||clients6.google.com^
 ||doubleclick.net^
 ||dts.innovid.com^
 ||files.adform.net^


### PR DESCRIPTION
multiple google services use the clients6.* subdomain including google docs and hangouts