### PR TITLE
update notice for graph.instagram.com block

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
  
 ## Notice
 
-- We block **`graph.facebook.com`**. The reason is that this domain serves many of the ads.  So, in order to use Facebook, you should consider to `whitelist either facebook's main app, or whitelist graph.facebook.com in your ad blocker` — **otherwise the Facebook app will not work** (there are no problems with facebook lite app and other facebook client apps).  If you are using `Facebook lite messenger`, then `whitelist the app or whitelist mqtt-mini.facebook.com`. Otherwise messenger will not work. We always recommend our users to use Open Source Facebook Clients for 100% ad free experience.  If you are facing any problems feel free to contact us through XDA or Telegram.
+- We block **`graph.facebook.com`** and **`graph.instagram.com`**. The reason is that this domain serves many of the ads.  So, in order to use Facebook, you should consider to `whitelist either facebook's main app, or whitelist graph.facebook.com in your ad blocker` — **otherwise the Facebook app will not work** (there are no problems with facebook lite app and other facebook client apps).  If you are using `Facebook lite messenger`, then `whitelist the app or whitelist mqtt-mini.facebook.com`. Otherwise messenger will not work. We always recommend our users to use Open Source Facebook Clients for 100% ad free experience.  If you are facing any problems feel free to contact us through XDA or Telegram.
 
 - GoodbyeAds-Ultra Discontinued.
  


### PR DESCRIPTION
As I found the `graph.instagram.com` domain also blocked, maybe the docs should mention that too.