### PR TITLE
Fix classification of Adblock filter files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Fix project's classification on GitHub.com
+*.txt linguist-detectable linguist-language=AdBlock


### PR DESCRIPTION
This pull-request fixes the syntax highlighting and language classification of this project's filter-list files, which are currently unrecognised by GitHub.

Note that due to caching issues, merging this may not update the project's classification immediately; pushing a follow-up change will fix it.