### PR TITLE
Removing edge.xero.com

### DIFF
--- a/Core/GoodbyeAds-Database.txt
+++ b/Core/GoodbyeAds-Database.txt
@@ -92,7 +92,6 @@ ff02::3 ip6-allhosts
 0.0.0.0 documentingreality.com
 0.0.0.0 dzc-metrics.mzstatic.com
 0.0.0.0 edge-star-shv-01-bom1.facebook.com
-0.0.0.0 edge.xero.com
 0.0.0.0 elblogdelnarco.com
 0.0.0.0 f5v1x3kgv5.com
 0.0.0.0 getmesec.xyz


### PR DESCRIPTION
Removing edge.xero.com

---

Hi there,

Which domain(s) should be unblocked?

edge.xero.com

Why should the domain(s) be unblocked?

Please remove 0.0.0.0 edge.xero.com as this is preventing access to the Xero accounting app. I've had to stop using Goodbye Ads to work around this.